### PR TITLE
Add Included classes in renaming

### DIFF
--- a/src/com/google/common/css/JobDescription.java
+++ b/src/com/google/common/css/JobDescription.java
@@ -53,6 +53,7 @@ public class JobDescription {
   public final ImmutableSet<String> allowedAtRules;
   public final String cssRenamingPrefix;
   public final List<String> excludedClassesFromRenaming;
+  public final List<String> includedClassesInRenaming;
   public final GssFunctionMapProvider gssFunctionMapProvider;
   public final SubstitutionMapProvider cssSubstitutionMapProvider;
   public final OutputRenamingMapFormat outputRenamingMapFormat;
@@ -113,6 +114,7 @@ public class JobDescription {
       boolean allowKeyframes, boolean allowWebkitKeyframes,
       boolean processDependencies, Set<String> allowedAtRules,
       String cssRenamingPrefix, List<String> excludedClassesFromRenaming,
+      List<String> includedClassesInRenaming,
       GssFunctionMapProvider gssFunctionMapProvider,
       SubstitutionMapProvider cssSubstitutionMapProvider,
       OutputRenamingMapFormat outputRenamingMapFormat) {
@@ -124,6 +126,7 @@ public class JobDescription {
     Preconditions.checkNotNull(trueConditionNames);
     Preconditions.checkNotNull(allowedAtRules);
     Preconditions.checkNotNull(excludedClassesFromRenaming);
+    Preconditions.checkNotNull(includedClassesInRenaming);
     this.inputs = ImmutableList.copyOf(inputs);
     this.copyrightNotice = copyrightNotice;
     this.outputFormat = outputFormat;
@@ -150,6 +153,8 @@ public class JobDescription {
     this.cssRenamingPrefix = cssRenamingPrefix;
     this.excludedClassesFromRenaming =
         ImmutableList.copyOf(excludedClassesFromRenaming);
+    this.includedClassesInRenaming =
+        ImmutableList.copyOf(includedClassesInRenaming);
     this.gssFunctionMapProvider = gssFunctionMapProvider;
     this.cssSubstitutionMapProvider = cssSubstitutionMapProvider;
     this.outputRenamingMapFormat = outputRenamingMapFormat;

--- a/src/com/google/common/css/JobDescriptionBuilder.java
+++ b/src/com/google/common/css/JobDescriptionBuilder.java
@@ -57,6 +57,7 @@ public class JobDescriptionBuilder {
   private boolean processDependencies;
   private String cssRenamingPrefix;
   private List<String> excludedClassesFromRenaming;
+  private List<String> includedClassesInRenaming;
   private GssFunctionMapProvider gssFunctionMapProvider;
   private SubstitutionMapProvider cssSubstitutionMapProvider;
   private OutputRenamingMapFormat outputRenamingMapFormat;
@@ -86,6 +87,7 @@ public class JobDescriptionBuilder {
     this.processDependencies = false;
     this.cssRenamingPrefix = "";
     this.excludedClassesFromRenaming = Lists.newArrayList();
+    this.includedClassesInRenaming = Lists.newArrayList();
     this.gssFunctionMapProvider = null;
     this.cssSubstitutionMapProvider = null;
     this.outputRenamingMapFormat = OutputRenamingMapFormat.JSCOMP_VARIABLE_MAP;
@@ -116,6 +118,8 @@ public class JobDescriptionBuilder {
     this.cssRenamingPrefix = jobToCopy.cssRenamingPrefix;
     setExcludedClassesFromRenaming(
         ImmutableList.copyOf(jobToCopy.excludedClassesFromRenaming));
+    setIncludedClassesInRenaming(
+        ImmutableList.copyOf(jobToCopy.includedClassesInRenaming));
     this.gssFunctionMapProvider = jobToCopy.gssFunctionMapProvider;
     this.cssSubstitutionMapProvider = jobToCopy.cssSubstitutionMapProvider;
     this.outputRenamingMapFormat = jobToCopy.outputRenamingMapFormat;
@@ -184,6 +188,15 @@ public class JobDescriptionBuilder {
     Preconditions.checkArgument(!excludedClassesFromRenaming.contains(null));
     this.excludedClassesFromRenaming =
         Lists.newArrayList(excludedClassesFromRenaming);
+    return this;
+  }
+
+  public JobDescriptionBuilder setIncludedClassesInRenaming(
+      List<String> includedClassesInRenaming) {
+    checkJobIsNotAlreadyCreated();
+    Preconditions.checkState(this.includedClassesInRenaming.isEmpty());
+    Preconditions.checkArgument(!includedClassesInRenaming.contains(null));
+    this.includedClassesInRenaming = includedClassesInRenaming;
     return this;
   }
 
@@ -380,8 +393,8 @@ public class JobDescriptionBuilder {
         allowUnrecognizedProperties, allowedUnrecognizedProperties, vendor,
         allowKeyframes, allowWebkitKeyframes, processDependencies,
         allowedAtRules, cssRenamingPrefix, excludedClassesFromRenaming,
-        gssFunctionMapProvider, cssSubstitutionMapProvider,
-        outputRenamingMapFormat);
+        includedClassesInRenaming, gssFunctionMapProvider,
+        cssSubstitutionMapProvider, outputRenamingMapFormat);
     return job;
   }
 }

--- a/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
@@ -154,6 +154,11 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
         "Pass the compiler a list of CSS class names that shoudn't be renamed.")
     private List<String> excludedClassesFromRenaming = Lists.newArrayList();
 
+    @Option(name = "--included-classes-in-renaming", usage =
+        "Pass the compiler a list of CSS class names that should be renamed"
+        + " even if their style is empty.")
+    private List<String> includedClassesInRenaming = Lists.newArrayList();
+
     // For enum values, args4j automatically lists all possible values when it
     // prints the usage information for the flag, so including them in the usage
     // message defined here would be redundant.
@@ -199,6 +204,7 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
       builder.setAllowWebkitKeyframes(true);
       builder.setProcessDependencies(true);
       builder.setExcludedClassesFromRenaming(excludedClassesFromRenaming);
+      builder.setIncludedClassesInRenaming(includedClassesInRenaming);
       builder.setSimplifyCss(true);
       builder.setEliminateDeadStyles(true);
       builder.setCssSubstitutionMapProvider(renamingType

--- a/src/com/google/common/css/compiler/passes/CssClassRenaming.java
+++ b/src/com/google/common/css/compiler/passes/CssClassRenaming.java
@@ -24,6 +24,8 @@ import com.google.common.css.compiler.ast.CssIdSelectorNode;
 import com.google.common.css.compiler.ast.DefaultTreeVisitor;
 import com.google.common.css.compiler.ast.MutatingVisitController;
 
+import java.util.List;
+
 /**
  * Compiler pass that does CSS class renaming given a renaming map.
  * 
@@ -34,12 +36,15 @@ public class CssClassRenaming extends DefaultTreeVisitor
     implements CssCompilerPass {
 
   private final MutatingVisitController visitController;
+  private final List<String> extraClassNames;
   private final SubstitutionMap cssClassRenamingMap;
   private final SubstitutionMap elementIdMap;
 
   public CssClassRenaming(MutatingVisitController visitController,
-      SubstitutionMap cssClassRenamingMap, SubstitutionMap elementIdMap) {
+      List<String> extraClassNames, SubstitutionMap cssClassRenamingMap,
+      SubstitutionMap elementIdMap) {
     this.visitController = visitController;
+    this.extraClassNames = extraClassNames;
     this.cssClassRenamingMap = cssClassRenamingMap;
     this.elementIdMap = elementIdMap;
   }
@@ -79,5 +84,10 @@ public class CssClassRenaming extends DefaultTreeVisitor
   @Override
   public void runPass() {
     visitController.startVisit(this);
+    for (String className : extraClassNames) {
+      if (cssClassRenamingMap != null) {
+        cssClassRenamingMap.get(className);
+      }
+    }
   }
 }

--- a/src/com/google/common/css/compiler/passes/PassRunner.java
+++ b/src/com/google/common/css/compiler/passes/PassRunner.java
@@ -174,7 +174,7 @@ public class PassRunner {
     // Rename class names
     if (recordingSubstitutionMap != null) {
       new CssClassRenaming(
-          cssTree.getMutatingVisitController(),
+          cssTree.getMutatingVisitController(), job.includedClassesInRenaming,
           recordingSubstitutionMap, null).runPass();
     }
   }


### PR DESCRIPTION
This PR adds an option to force classes to be included in the renaming map.

The background and motivation for this patch were [discussed on the `closure-stylesheets-discuess` email list](https://groups.google.com/d/msg/closure-stylesheets-discuss/OGum2yekOIc/_Flbc5cO69gJ).

Great to see Closure Stylesheets on GitHub!