### PR TITLE
Fix issue with lang

### DIFF
--- a/src/com/google/common/css/compiler/passes/ProcessRefiners.java
+++ b/src/com/google/common/css/compiler/passes/ProcessRefiners.java
@@ -86,7 +86,7 @@ public class ProcessRefiners extends DefaultTreeVisitor
   }
 
   private boolean handleLang(CssPseudoClassNode refiner) {
-    if (!refiner.getRefinerName().equals("lang")) {
+    if (!refiner.getRefinerName().equals("lang(")) {
       errorManager.report(new GssError(NOT_LANG_ERROR_MESSAGE,
           refiner.getSourceCodeLocation()));
       return false;

--- a/tests/com/google/common/css/compiler/passes/ProcessRefinersTest.java
+++ b/tests/com/google/common/css/compiler/passes/ProcessRefinersTest.java
@@ -255,4 +255,11 @@ public class ProcessRefinersTest extends NewFunctionalTestBase {
     runParseB(0, "-23n+0");
     runParseB(0, "-21n-0");
   }
+
+  public void testLang() throws Exception {
+    simplifyCss = true;
+    parseAndRun("div :lang(en) {}");
+    assertEquals("div :lang(en){}",
+        compactPrintedResult);
+  }
 }


### PR DESCRIPTION
When the pseudo-class ":lang(en)" is used, closure-stylesheets
produces the error :
"a pseudo-class which takes arguments has to be ':lang()' or has to
start with 'nth-'"

In parser (com/google/common/css/compiler/ast/GssParserCC.jj) the
LANGFUNCTION variable is declared like this :
< LANGFUNCTION: "lang" <LEFTROUND> >

So, the refiner name is equal to "lang(" and not to "lang"