### PR TITLE
Add --input-renaming-map and --input-renaming-map-format options

### DIFF
--- a/src/com/google/common/css/JobDescription.java
+++ b/src/com/google/common/css/JobDescription.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import java.io.Reader;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -62,7 +63,9 @@ public class JobDescription {
   public final List<String> excludedClassesFromRenaming;
   public final GssFunctionMapProvider gssFunctionMapProvider;
   public final SubstitutionMapProvider cssSubstitutionMapProvider;
-  public final OutputRenamingMapFormat outputRenamingMapFormat;
+  public final RenamingMapFormat outputRenamingMapFormat;
+  public final RenamingMapFormat inputRenamingMapFormat;
+  public final Reader inputRenamingMapReader;
   public final boolean preserveComments;
   public final boolean suppressDependencyCheck;
   public final Map<String, Integer> compileConstants;
@@ -135,7 +138,9 @@ public class JobDescription {
       String cssRenamingPrefix, List<String> excludedClassesFromRenaming,
       GssFunctionMapProvider gssFunctionMapProvider,
       SubstitutionMapProvider cssSubstitutionMapProvider,
-      OutputRenamingMapFormat outputRenamingMapFormat,
+      RenamingMapFormat outputRenamingMapFormat,
+      RenamingMapFormat inputRenamingMapFormat,
+      Reader inputRenamingMapReader,
       boolean preserveComments,
       boolean suppressDependencyCheck, Map<String, Integer> compileConstants,
       boolean createSourceMap,
@@ -182,6 +187,8 @@ public class JobDescription {
     this.gssFunctionMapProvider = gssFunctionMapProvider;
     this.cssSubstitutionMapProvider = cssSubstitutionMapProvider;
     this.outputRenamingMapFormat = outputRenamingMapFormat;
+    this.inputRenamingMapFormat = inputRenamingMapFormat;
+    this.inputRenamingMapReader = inputRenamingMapReader;
     this.preserveComments = preserveComments;
     this.suppressDependencyCheck = suppressDependencyCheck;
     this.compileConstants = ImmutableMap.copyOf(compileConstants);

--- a/src/com/google/common/css/JobDescriptionBuilder.java
+++ b/src/com/google/common/css/JobDescriptionBuilder.java
@@ -27,6 +27,7 @@ import com.google.common.css.JobDescription.OutputFormat;
 import com.google.common.css.JobDescription.OutputOrientation;
 import com.google.common.css.JobDescription.SourceMapDetailLevel;
 
+import java.io.Reader;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +66,9 @@ public class JobDescriptionBuilder {
   List<String> excludedClassesFromRenaming;
   GssFunctionMapProvider gssFunctionMapProvider;
   SubstitutionMapProvider cssSubstitutionMapProvider;
-  OutputRenamingMapFormat outputRenamingMapFormat;
+  RenamingMapFormat outputRenamingMapFormat;
+  RenamingMapFormat inputRenamingMapFormat;
+  Reader inputRenamingMapReader;
   boolean preserveComments;
   boolean suppressDependencyCheck;
   Map<String, Integer> compileConstants;
@@ -103,7 +106,9 @@ public class JobDescriptionBuilder {
     this.excludedClassesFromRenaming = Lists.newArrayList();
     this.gssFunctionMapProvider = null;
     this.cssSubstitutionMapProvider = null;
-    this.outputRenamingMapFormat = OutputRenamingMapFormat.JSCOMP_VARIABLE_MAP;
+    this.outputRenamingMapFormat = RenamingMapFormat.JSCOMP_VARIABLE_MAP;
+    this.inputRenamingMapFormat = this.outputRenamingMapFormat;
+    this.inputRenamingMapReader = null;
     this.preserveComments = false;
     this.suppressDependencyCheck = false;
     this.compileConstants = new HashMap<>();
@@ -143,6 +148,8 @@ public class JobDescriptionBuilder {
     this.gssFunctionMapProvider = jobToCopy.gssFunctionMapProvider;
     this.cssSubstitutionMapProvider = jobToCopy.cssSubstitutionMapProvider;
     this.outputRenamingMapFormat = jobToCopy.outputRenamingMapFormat;
+    this.inputRenamingMapFormat = jobToCopy.inputRenamingMapFormat;
+    this.inputRenamingMapReader = jobToCopy.inputRenamingMapReader;
     this.preserveComments = jobToCopy.preserveComments;
     this.suppressDependencyCheck = jobToCopy.suppressDependencyCheck;
     setCompileConstants(jobToCopy.compileConstants);
@@ -388,10 +395,21 @@ public class JobDescriptionBuilder {
   }
 
   public JobDescriptionBuilder setOutputRenamingMapFormat(
-      OutputRenamingMapFormat format) {
+      RenamingMapFormat outputFormat) {
     checkJobIsNotAlreadyCreated();
-    this.outputRenamingMapFormat = format;
+    this.outputRenamingMapFormat = outputFormat;
     return this;
+  }
+
+  public void setInputRenamingMapFormat(RenamingMapFormat inputFormat) {
+    checkJobIsNotAlreadyCreated();
+    Preconditions.checkNotNull(inputFormat);
+    this.inputRenamingMapFormat = inputFormat;
+  }
+
+  public void setInputRenamingMapReader(Reader inputRenamingMapReader) {
+    checkJobIsNotAlreadyCreated();
+    this.inputRenamingMapReader = inputRenamingMapReader;
   }
 
   public JobDescriptionBuilder setAllowMozDocument(boolean allow) {
@@ -483,7 +501,7 @@ public class JobDescriptionBuilder {
         allowKeyframes, allowWebkitKeyframes, processDependencies,
         allowedAtRules, cssRenamingPrefix, excludedClassesFromRenaming,
         gssFunctionMapProvider, cssSubstitutionMapProvider,
-        outputRenamingMapFormat, preserveComments, suppressDependencyCheck, compileConstants,
+        outputRenamingMapFormat, inputRenamingMapFormat, inputRenamingMapReader, preserveComments, suppressDependencyCheck, compileConstants,
         createSourceMap, sourceMapLevel, preserveImportantComments);
     return job;
   }

--- a/src/com/google/common/css/RecordingSubstitutionMap.java
+++ b/src/com/google/common/css/RecordingSubstitutionMap.java
@@ -87,7 +87,7 @@ public class RecordingSubstitutionMap implements SubstitutionMap.Initializable {
 
   /**
    * @return The recorded mappings in the order they were created. This output may be used with
-   *     {@link OutputRenamingMapFormat#writeRenamingMap}
+   *     {@link RenamingMapFormat#writeRenamingMap}
    */
   public Map<String, String> getMappings() {
     return ImmutableMap.copyOf(mappings);
@@ -128,8 +128,8 @@ public class RecordingSubstitutionMap implements SubstitutionMap.Initializable {
     /**
      * Specifies mappings to {@linkplain Initializable initialize} the delegate with. Multiple calls
      * putAll. This can be used to reconstitute a map that was written out by {@link
-     * OutputRenamingMapFormat#writeRenamingMap} from the output of {@link
-     * OutputRenamingMapFormat#readRenamingMap}.
+     * RenamingMapFormat#writeRenamingMap} from the output of {@link
+     * RenamingMapFormat#readRenamingMap}.
      */
     public Builder withMappings(Map<? extends String, ? extends String> m) {
       this.mappings.putAll(m);

--- a/src/com/google/common/css/RenamingMapFormat.java
+++ b/src/com/google/common/css/RenamingMapFormat.java
@@ -45,16 +45,16 @@ import java.util.Properties;
  *
  * @author bolinfest@google.com (Michael Bolin)
  */
-public enum OutputRenamingMapFormat {
+public enum RenamingMapFormat {
   /**
-   * Writes the mapping as JSON, passed as an argument to
+   * Reads/Writes the mapping as JSON, passed as an argument to
    * {@code goog.setCssNameMapping()}. Designed for use with the Closure
    * Library in compiled mode.
    */
   CLOSURE_COMPILED("goog.setCssNameMapping(%s);\n"),
 
   /**
-   * Writes the mapping as JSON, passed as an argument to
+   * Reads/Writes the mapping as JSON, passed as an argument to
    * {@code goog.setCssNameMapping()} using the 'BY_WHOLE' mapping style.
    * Designed for use with the Closure Library in compiled mode where the CSS
    * name substitutions are taken as-is, which allows, e.g., using
@@ -75,19 +75,19 @@ public enum OutputRenamingMapFormat {
   },
 
   /**
-   * Writes the mapping as JSON, assigned to the global JavaScript variable
+   * Reads/Writes the mapping as JSON, assigned to the global JavaScript variable
    * {@code CLOSURE_CSS_NAME_MAPPING}. Designed for use with the Closure
    * Library in uncompiled mode.
    */
   CLOSURE_UNCOMPILED("CLOSURE_CSS_NAME_MAPPING = %s;\n"),
 
   /**
-   * Writes the mapping as JSON.
+   * Reads/Writes the mapping as JSON.
    */
   JSON,
 
   /**
-   * Writes the mapping in a .properties file format, such that it can be read
+   * Reads/Writes the mapping from/in a .properties file format, such that it can be read
    * by {@link Properties}.
    */
   PROPERTIES {
@@ -132,12 +132,12 @@ public enum OutputRenamingMapFormat {
 
   private final String formatString;
 
-  private OutputRenamingMapFormat(String formatString) {
+  private RenamingMapFormat(String formatString) {
     Preconditions.checkNotNull(formatString);
     this.formatString = formatString;
   }
 
-  private OutputRenamingMapFormat() {
+  private RenamingMapFormat() {
     this("%s");
   }
 

--- a/src/com/google/common/css/SubstitutionMap.java
+++ b/src/com/google/common/css/SubstitutionMap.java
@@ -46,11 +46,11 @@ public interface SubstitutionMap {
    *
    * <p>After the first compilation,
    * {@link RecordingSubstitutionMap#getRenameMap} may be used with
-   * an {@link OutputRenamingMapFormat} to serialize the renaming map
+   * an {@link RenamingMapFormat} to serialize the renaming map
    * in a form that can be used with Closure Library code or Closure
    * Templates.
    *
-   * <p>Before a re-compile, {@link OutputRenamingMapFormat#readRenamingMap}
+   * <p>Before a re-compile, {@link RenamingMapFormat#readRenamingMap}
    * can be used to generate a set of initial mappings that can be
    * passed to {@link Initializable#initializeWithMappings} to prepare
    * a structurally equivalent substitution map to produce IDs that do

--- a/src/com/google/common/css/compiler/commandline/DefaultCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/DefaultCommandLineCompiler.java
@@ -68,9 +68,10 @@ public class DefaultCommandLineCompiler extends AbstractCommandLineCompiler<JobD
    *
    * @param job The inputs the compiler should process and the options to use.
    * @param errorManager The error manager to use for error reporting.
+   * @throws IOException
    */
   protected DefaultCommandLineCompiler(JobDescription job,
-      ExitCodeHandler exitCodeHandler, ErrorManager errorManager) {
+      ExitCodeHandler exitCodeHandler, ErrorManager errorManager) throws IOException {
     super(job, exitCodeHandler);
     this.errorManager = errorManager;
     this.passRunner = new PassRunner(job, errorManager);

--- a/tests/com/google/common/css/RecordingSubstitutionMapTest.java
+++ b/tests/com/google/common/css/RecordingSubstitutionMapTest.java
@@ -36,7 +36,7 @@ public final class RecordingSubstitutionMapTest extends TestCase {
   }
 
   public final void testReadAndWrite() throws IOException {
-    for (OutputRenamingMapFormat format : OutputRenamingMapFormat.values()) {
+    for (RenamingMapFormat format : RenamingMapFormat.values()) {
       RecordingSubstitutionMap recording =
           new RecordingSubstitutionMap.Builder().withSubstitutionMap(createDelegate()).build();
       // Put some stuff into the map.


### PR DESCRIPTION
With these options, it is possible to provide a file
that contain a renaming map in command line.

This feature is useful to build several css files
with the same map (like themes, specific devices, ...).

The generated map contains the content of the input map and
others renaming fields that did not in input map.
