### PR TITLE
DRY in exception handling

### DIFF
--- a/src/com/google/common/css/compiler/gssfunctions/GssFunctions.java
+++ b/src/com/google/common/css/compiler/gssfunctions/GssFunctions.java
@@ -379,14 +379,9 @@ public class GssFunctions {
             Integer.parseInt(hueToAdd),
             Integer.parseInt(saturationToAdd),
             Integer.parseInt(brightnessToAdd));
-      } catch (NumberFormatException e) {
-        String message = String.format("Could not parse the integer arguments"
-            + " for the function 'addHsbToCssColor'. The list of arguments was:"
-            + " %s, %s, %s, %s. ",
-            baseColorString, hueToAdd, saturationToAdd, brightnessToAdd);
-        throw new GssFunctionException(message);
       } catch (IllegalArgumentException e) {
-        String message = String.format("Could not parse the color argument"
+        String message = String.format("Could not parse the "
+            + (e instanceof NumberFormatException ? "integer arguments" : "color argument")
             + " for the function 'addHsbToCssColor'. The list of arguments was:"
             + " %s, %s, %s, %s. ",
             baseColorString, hueToAdd, saturationToAdd, brightnessToAdd);


### PR DESCRIPTION
We can't use Java 7 multi catch as NumberFormatException is a
subclass of IllegalArgumentException.