### PR TITLE
Added --allow-duplicate-declarations flag 

### DIFF
--- a/src/com/google/common/css/JobDescription.java
+++ b/src/com/google/common/css/JobDescription.java
@@ -48,6 +48,7 @@ public class JobDescription {
   public final boolean eliminateDeadStyles;
   public final boolean allowDefPropagation;
   public final boolean allowUnrecognizedFunctions;
+  public final boolean allowDuplicateDeclarations;
   public final Set<String> allowedNonStandardFunctions;
   public final boolean allowUnrecognizedProperties;
   public final Set<String> allowedUnrecognizedProperties;
@@ -125,6 +126,7 @@ public class JobDescription {
       boolean swapLeftRightInUrl, boolean simplifyCss,
       boolean eliminateDeadStyles, boolean allowDefPropagation,
       boolean allowUnrecognizedFunctions,
+      boolean allowDuplicateDeclarations,
       Set<String> allowedNonStandardFunctions,
       boolean allowUnrecognizedProperties,
       Set<String> allowedUnrecognizedProperties, boolean allowUndefinedConstants,
@@ -163,6 +165,7 @@ public class JobDescription {
     this.eliminateDeadStyles = eliminateDeadStyles;
     this.allowDefPropagation = allowDefPropagation;
     this.allowUnrecognizedFunctions = allowUnrecognizedFunctions;
+    this.allowDuplicateDeclarations = allowDuplicateDeclarations;
     this.allowedNonStandardFunctions = ImmutableSet.copyOf(
         allowedNonStandardFunctions);
     this.allowUnrecognizedProperties = allowUnrecognizedProperties;

--- a/src/com/google/common/css/JobDescriptionBuilder.java
+++ b/src/com/google/common/css/JobDescriptionBuilder.java
@@ -52,6 +52,7 @@ public class JobDescriptionBuilder {
   boolean eliminateDeadStyles;
   boolean allowDefPropagation;
   boolean allowUnrecognizedFunctions;
+  boolean allowDuplicateDeclarations;
   Set<String> allowedNonStandardFunctions;
   boolean allowUnrecognizedProperties;
   Set<String> allowedUnrecognizedProperties;
@@ -89,6 +90,7 @@ public class JobDescriptionBuilder {
     this.eliminateDeadStyles = false;
     this.allowDefPropagation = false;
     this.allowUnrecognizedFunctions = false;
+    this.allowDuplicateDeclarations = false;
     this.allowedNonStandardFunctions = Sets.newHashSet();
     this.allowUnrecognizedProperties = false;
     this.allowedUnrecognizedProperties = Sets.newHashSet();
@@ -125,6 +127,7 @@ public class JobDescriptionBuilder {
     this.eliminateDeadStyles = jobToCopy.eliminateDeadStyles;
     this.allowDefPropagation = jobToCopy.allowDefPropagation;
     this.allowUnrecognizedFunctions = jobToCopy.allowUnrecognizedFunctions;
+    this.allowDuplicateDeclarations = jobToCopy.allowDuplicateDeclarations;
     this.allowedNonStandardFunctions =
         ImmutableSet.copyOf(jobToCopy.allowedNonStandardFunctions);
     this.allowUnrecognizedProperties = jobToCopy.allowUnrecognizedProperties;
@@ -324,8 +327,18 @@ public class JobDescriptionBuilder {
     return this;
   }
 
+  public JobDescriptionBuilder setAllowDuplicateDeclarations(boolean allow) {
+    checkJobIsNotAlreadyCreated();
+    this.allowDuplicateDeclarations = allow;
+    return this;
+  }
+
   public JobDescriptionBuilder allowUnrecognizedFunctions() {
     return setAllowUnrecognizedFunctions(true);
+  }
+
+  public JobDescriptionBuilder allowDuplicateDeclarations() {
+    return setAllowDuplicateDeclarations(true);
   }
 
   public JobDescriptionBuilder setAllowedNonStandardFunctions(
@@ -464,7 +477,7 @@ public class JobDescriptionBuilder {
         copyrightNotice, outputFormat, inputOrientation, outputOrientation,
         optimize, trueConditionNames, useInternalBidiFlipper, swapLtrRtlInUrl,
         swapLeftRightInUrl, simplifyCss, eliminateDeadStyles,
-        allowDefPropagation, allowUnrecognizedFunctions, allowedNonStandardFunctions,
+        allowDefPropagation, allowUnrecognizedFunctions, allowDuplicateDeclarations, allowedNonStandardFunctions,
         allowUnrecognizedProperties, allowedUnrecognizedProperties, allowUndefinedConstants,
         allowMozDocument, vendor,
         allowKeyframes, allowWebkitKeyframes, processDependencies,

--- a/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
@@ -154,6 +154,10 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
         "Allow unrecognized functions.")
     private boolean allowUnrecognizedFunctions = false;
 
+    @Option(name = "--allow-duplicate-declarations", usage =
+        "Allow duplicate declarations.")
+    private boolean allowDuplicateDeclarations = false;
+
     @Option(name = "--allowed-non-standard-function", usage =
         "Specify a non-standard function to whitelist, like alpha()")
     private List<String> allowedNonStandardFunctions = Lists.newArrayList();
@@ -224,6 +228,7 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
       builder.setTrueConditionNames(trueConditions);
       builder.setAllowDefPropagation(allowDefPropagation);
       builder.setAllowUnrecognizedFunctions(allowUnrecognizedFunctions);
+      builder.setAllowDuplicateDeclarations(allowDuplicateDeclarations);
       builder.setAllowedNonStandardFunctions(allowedNonStandardFunctions);
       builder.setAllowedUnrecognizedProperties(allowedUnrecognizedProperties);
       builder.setAllowUnrecognizedProperties(allowUnrecognizedProperties);

--- a/src/com/google/common/css/compiler/passes/PassRunner.java
+++ b/src/com/google/common/css/compiler/passes/PassRunner.java
@@ -142,10 +142,13 @@ public class PassRunner {
       new AbbreviatePositionalValues(
           cssTree.getMutatingVisitController()).runPass();
     }
-    if (job.eliminateDeadStyles) {
-      // Report errors for duplicate declarations
+    // Report errors for duplicate declarations
+    if (!job.allowDuplicateDeclarations) {
       new DisallowDuplicateDeclarations(
           cssTree.getVisitController(), errorManager).runPass();
+    }
+
+    if (job.eliminateDeadStyles) {
       // Split rules by selector and declaration.
       new SplitRulesetNodes(cssTree.getMutatingVisitController()).runPass();
       // Dead code elimination.


### PR DESCRIPTION
Allow multiple declarations of css definitions, so there is no need to use alternate flag.