### PR TITLE
Add Customized Splitter instead of hard code character '-'

### DIFF
--- a/src/com/google/common/css/SplittingSubstitutionMap.java
+++ b/src/com/google/common/css/SplittingSubstitutionMap.java
@@ -16,6 +16,7 @@
 
 package com.google.common.css;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
@@ -24,18 +25,51 @@ import com.google.common.collect.Maps;
 import java.util.Map;
 
 /**
- * The CSS class substitution map which splits CSS class names on the "-" (dash)
- * character and processes them separately using a delegate substitution map.
+ * <p>The CSS class substitution map which splits CSS class names on the "-" (dash)
+ * character and processes them separately using a delegate substitution map.</p>
  *
+ * <p>At the same time, if customized splitter character is assigned, the CSS class 
+ * substitution map will splits CSS class names on the specific character;</p>
+ * 
  * @author dgajda@google.com (Damian Gajda)
  */
 public class SplittingSubstitutionMap implements
     MultipleMappingSubstitutionMap {
-  private static final Splitter DASH = Splitter.on('-');
+  public static final char DEFAULT_CSS_CLASS_SPLITTER_CHAR = '-';
+  private static final Splitter DEFAULT_CSS_CLASS_SPLITTER = Splitter.
+      on(DEFAULT_CSS_CLASS_SPLITTER_CHAR);
   private final SubstitutionMap delegate;
-
+  
+  /**
+   * Make splitter become configurable. The value can be decided by the option 
+   * user input. Default value is dash character '-'.
+  */
+  private char splitterChar = DEFAULT_CSS_CLASS_SPLITTER_CHAR;
+  private Splitter splitter = DEFAULT_CSS_CLASS_SPLITTER;
+  
   public SplittingSubstitutionMap(SubstitutionMap substitutionMap) {
     this.delegate = substitutionMap;
+  }
+  
+  /**
+   * Please NOTE: this method is used as internal method when developers want to 
+   * introduce customized css class splitter. So do not call it manually.
+   * 
+   * @param splitterChar The customized splitter you need.
+   */
+  public void registerSplitter(char splitterChar) {
+    this.splitterChar = splitterChar;
+    this.splitter = Splitter.on(splitterChar);
+  }
+  
+  /**
+   * Please NOTE: this method is used as testing method. So do not call it manually.
+   * 
+   * @return splitterChar
+   */
+  @VisibleForTesting
+  public char getSplitterChar() {
+    return splitterChar;
   }
 
   @Override
@@ -48,8 +82,8 @@ public class SplittingSubstitutionMap implements
     Preconditions.checkNotNull(key, "CSS key cannot be null");
     Preconditions.checkArgument(!key.isEmpty(), "CSS key cannot be empty");
 
-    // Efficiently handle the common case with no dashes.
-    if (key.indexOf('-') == -1) {
+    // Efficiently handle the common case with no specific splitter character.
+    if (key.indexOf(this.splitterChar) == -1) {
       String value = delegate.get(key);
       return ValueWithMappings.createForSingleMapping(key, value);
     }
@@ -58,9 +92,9 @@ public class SplittingSubstitutionMap implements
     // Cannot use an ImmutableMap.Builder because the same key/value pair may be
     // inserted more than once in this loop.
     Map<String, String> mappings = Maps.newHashMap();
-    for (String part : DASH.split(key)) {
+    for (String part : splitter.split(key)) {
       if (buffer.length() != 0) {
-        buffer.append('-');
+        buffer.append(this.splitterChar);
       }
 
       String value = delegate.get(part);

--- a/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
@@ -33,6 +33,8 @@ import com.google.common.css.JobDescription.SourceMapDetailLevel;
 import com.google.common.css.JobDescriptionBuilder;
 import com.google.common.css.OutputRenamingMapFormat;
 import com.google.common.css.SourceCode;
+import com.google.common.css.SplittingSubstitutionMap;
+import com.google.common.css.SubstitutionMap;
 import com.google.common.css.Vendor;
 import com.google.common.css.compiler.ast.ErrorManager;
 import com.google.common.css.compiler.gssfunctions.DefaultGssFunctionMapProvider;
@@ -61,6 +63,9 @@ import javax.annotation.Nullable;
  * @author bolinfest@google.com (Michael Bolin)
  */
 public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
+
+  private static final String DEFAULT_CSS_CLASS_SLIPPTER_SINGLE_CHARACTER_STRING = 
+      String.valueOf(SplittingSubstitutionMap.DEFAULT_CSS_CLASS_SPLITTER_CHAR);
 
   protected ClosureCommandLineCompiler(JobDescription job,
       ExitCodeHandler exitCodeHandler, ErrorManager errorManager) {
@@ -202,6 +207,12 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
         usage = "Specify integer constants to be used in for loops. Invoke for each const, e.g.: "
         + "--const=VAR1=VALUE1 --const=VAR2=VALUE2")
     private Map<String, String> compileConstants = new HashMap<>();
+    
+    @Option(name = "--css-class-splitter", 
+    	usage = "Define your single-character customized splitter when process " 
+        + "css class names. Default value is '-'. If you want to enable this feature, " 
+        + "please choose 'DEBUG' or 'CLOSURE' for '--rename'")
+    private String splitter = DEFAULT_CSS_CLASS_SLIPPTER_SINGLE_CHARACTER_STRING;
 
     /**
      * All remaining arguments are considered input CSS files.
@@ -282,6 +293,43 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
         parsedConstants.put(entry.getKey(), Integer.parseInt(entry.getValue()));
       }
       return parsedConstants;
+    }
+    
+    /**
+     * Only following requirements are satisfied, the customized splitter will 
+     * be used:
+     * <ul>
+     * <li>
+     * Option <code>css-class-splitter</code> is NOT Null or empty;
+     * </li>
+     * <li>
+     * Option <code>css-class-splitter</code> only contains <b>ONE</b> character;
+     * </li>
+     * <li>
+     * Option <code>css-class-splitter</code> doesn't equal to default value <b>'-'</b>;
+     * </li>
+     * <li>
+     * Option <code>renamingType</code> is <b>RenamingType.CLOSURE</b> or 
+     * <b>RenamingType.DEBUG</b>;
+     * </li>
+     * </ul>
+     */
+    @VisibleForTesting
+    void registerSplitterIfExist() {
+      if (!Strings.isNullOrEmpty(splitter) 
+            && !splitter.equals(DEFAULT_CSS_CLASS_SLIPPTER_SINGLE_CHARACTER_STRING) 
+            && (renamingType.equals(RenamingType.CLOSURE) 
+            || renamingType.equals(RenamingType.DEBUG))) {
+    	SubstitutionMap map = renamingType.getCssSubstitutionMapProvider().get();
+    	if (map instanceof SplittingSubstitutionMap) {
+    	  ((SplittingSubstitutionMap)map).registerSplitter(splitter.charAt(0));
+    	}
+      }
+    }
+    
+    @VisibleForTesting
+    RenamingType getRenamingType() {
+      return renamingType;
     }
   }
 
@@ -386,8 +434,16 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
       return null;
     }
 
+    boolean errorHappen = false;
+    if (!Strings.isNullOrEmpty(flags.splitter) && flags.splitter.length() > 1) {
+      System.err.println("\nERROR: Only single character is supported for --css-class-splitter.\n");
+      errorHappen = true;
+    }
     if (flags.arguments.isEmpty()) {
       System.err.println("\nERROR: No input files specified.\n");
+      errorHappen = true;
+    }
+    if (errorHappen) {
       argsParser.printUsage(System.err);
       exitCodeHandler.processExitCode(
           AbstractCommandLineCompiler.ERROR_MESSAGE_EXIT_CODE);
@@ -404,6 +460,7 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
       return;
     }
 
+    flags.registerSplitterIfExist();
     JobDescription job = flags.createJobDescription();
     OutputInfo info = flags.createOutputInfo();
     executeJob(job, exitCodeHandler, info);

--- a/src/com/google/common/css/compiler/commandline/RenamingType.java
+++ b/src/com/google/common/css/compiler/commandline/RenamingType.java
@@ -52,8 +52,9 @@ enum RenamingType {
 
 
   /**
-   * Each chunk of a CSS class as delimited by '-' is renamed using the
-   * shortest available name.
+   * Each chunk of a CSS class as delimited by specific splitter is 
+   * renamed using the shortest available name. Default specific 
+   * splitter is '-'.
    */
   CLOSURE(new SubstitutionMapProvider() {
     @Override

--- a/tests/com/google/common/css/compiler/commandline/ClosureCommandLineCompilerTest.java
+++ b/tests/com/google/common/css/compiler/commandline/ClosureCommandLineCompilerTest.java
@@ -19,12 +19,15 @@ import com.google.common.css.ExitCodeHandler;
 import com.google.common.css.JobDescription;
 import com.google.common.css.JobDescriptionBuilder;
 import com.google.common.css.SourceCode;
+import com.google.common.css.SplittingSubstitutionMap;
 import com.google.common.css.compiler.ast.ErrorManager;
 import com.google.common.css.compiler.ast.testing.NewFunctionalTestBase;
 
 import junit.framework.TestCase;
 
 public class ClosureCommandLineCompilerTest extends TestCase {
+
+  private static final String TEST_SPLITTER = "-";
 
   static final ExitCodeHandler EXIT_CODE_HANDLER =
       new ExitCodeHandler() {
@@ -63,5 +66,18 @@ public class ClosureCommandLineCompilerTest extends TestCase {
         ClosureCommandLineCompiler.parseArgs(new String[] {"/dev/null"}, EXIT_CODE_HANDLER);
     JobDescription jobDescription = flags.createJobDescription();
     assertTrue(jobDescription.allowDefPropagation);
+  }
+  
+  public void testAssignCustomizedSplitter() throws Exception {
+    ClosureCommandLineCompiler.Flags flags =
+        ClosureCommandLineCompiler.parseArgs(new String[] {"--allow-unrecognized-functions", 
+            "--allow-unrecognized-properties", "--rename", "CLOSURE", 
+            "--css-class-splitter", TEST_SPLITTER, "/dev/null"}, EXIT_CODE_HANDLER);
+    flags.registerSplitterIfExist();
+    assertEquals("Type of RenamingType should be CLOSURE", 
+        flags.getRenamingType().name(), "CLOSURE");
+    assertEquals("The passed splitter should be the same as it in test case.", 
+        TEST_SPLITTER.charAt(0), 
+        ((SplittingSubstitutionMap)(flags.getRenamingType().getCssSubstitutionMapProvider().get())).getSplitterChar());
   }
 }


### PR DESCRIPTION
Add one more option "--css-class-splitter" when we use closure-stylesheets. By this developers can assign any single character as splitter for closure-stylesheets to use.