### PR TITLE
Allow duplicate declarations

### DIFF
--- a/src/com/google/common/css/JobDescription.java
+++ b/src/com/google/common/css/JobDescription.java
@@ -48,6 +48,7 @@ public class JobDescription {
   public final boolean eliminateDeadStyles;
   public final boolean allowDefPropagation;
   public final boolean allowUnrecognizedFunctions;
+  public final boolean allowDuplicateDeclarations;
   public final Set<String> allowedNonStandardFunctions;
   public final boolean allowUnrecognizedProperties;
   public final Set<String> allowedUnrecognizedProperties;
@@ -125,6 +126,7 @@ public class JobDescription {
       boolean swapLeftRightInUrl, boolean simplifyCss,
       boolean eliminateDeadStyles, boolean allowDefPropagation,
       boolean allowUnrecognizedFunctions,
+      boolean allowDuplicateDeclarations,
       Set<String> allowedNonStandardFunctions,
       boolean allowUnrecognizedProperties,
       Set<String> allowedUnrecognizedProperties, boolean allowUndefinedConstants,
@@ -163,6 +165,7 @@ public class JobDescription {
     this.eliminateDeadStyles = eliminateDeadStyles;
     this.allowDefPropagation = allowDefPropagation;
     this.allowUnrecognizedFunctions = allowUnrecognizedFunctions;
+    this.allowDuplicateDeclarations = allowDuplicateDeclarations;
     this.allowedNonStandardFunctions = ImmutableSet.copyOf(
         allowedNonStandardFunctions);
     this.allowUnrecognizedProperties = allowUnrecognizedProperties;

--- a/src/com/google/common/css/JobDescriptionBuilder.java
+++ b/src/com/google/common/css/JobDescriptionBuilder.java
@@ -52,6 +52,7 @@ public class JobDescriptionBuilder {
   boolean eliminateDeadStyles;
   boolean allowDefPropagation;
   boolean allowUnrecognizedFunctions;
+  boolean allowDuplicateDeclarations;
   Set<String> allowedNonStandardFunctions;
   boolean allowUnrecognizedProperties;
   Set<String> allowedUnrecognizedProperties;
@@ -89,6 +90,7 @@ public class JobDescriptionBuilder {
     this.eliminateDeadStyles = false;
     this.allowDefPropagation = false;
     this.allowUnrecognizedFunctions = false;
+    this.allowDuplicateDeclarations = false;
     this.allowedNonStandardFunctions = Sets.newHashSet();
     this.allowUnrecognizedProperties = false;
     this.allowedUnrecognizedProperties = Sets.newHashSet();
@@ -125,6 +127,7 @@ public class JobDescriptionBuilder {
     this.eliminateDeadStyles = jobToCopy.eliminateDeadStyles;
     this.allowDefPropagation = jobToCopy.allowDefPropagation;
     this.allowUnrecognizedFunctions = jobToCopy.allowUnrecognizedFunctions;
+    this.allowDuplicateDeclarations = jobToCopy.allowDuplicateDeclarations;
     this.allowedNonStandardFunctions =
         ImmutableSet.copyOf(jobToCopy.allowedNonStandardFunctions);
     this.allowUnrecognizedProperties = jobToCopy.allowUnrecognizedProperties;
@@ -335,6 +338,16 @@ public class JobDescriptionBuilder {
     return this;
   }
 
+  public JobDescriptionBuilder setAllowDuplicateDeclarations(boolean allow) {
+      checkJobIsNotAlreadyCreated();
+      this.allowDuplicateDeclarations = allow;
+      return this;
+  }
+
+  public JobDescriptionBuilder allowDuplicateDeclarations() {
+    return setAllowDuplicateDeclarations(true);
+  }
+
   public JobDescriptionBuilder setAllowUnrecognizedProperties(boolean allow) {
     checkJobIsNotAlreadyCreated();
     this.allowUnrecognizedProperties = allow;
@@ -464,8 +477,9 @@ public class JobDescriptionBuilder {
         copyrightNotice, outputFormat, inputOrientation, outputOrientation,
         optimize, trueConditionNames, useInternalBidiFlipper, swapLtrRtlInUrl,
         swapLeftRightInUrl, simplifyCss, eliminateDeadStyles,
-        allowDefPropagation, allowUnrecognizedFunctions, allowedNonStandardFunctions,
-        allowUnrecognizedProperties, allowedUnrecognizedProperties, allowUndefinedConstants,
+        allowDefPropagation, allowUnrecognizedFunctions, allowDuplicateDeclarations,
+        allowedNonStandardFunctions, allowUnrecognizedProperties,
+        allowedUnrecognizedProperties, allowUndefinedConstants,
         allowMozDocument, vendor,
         allowKeyframes, allowWebkitKeyframes, processDependencies,
         allowedAtRules, cssRenamingPrefix, excludedClassesFromRenaming,

--- a/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
@@ -153,6 +153,10 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
         "Allow unrecognized functions.")
     private boolean allowUnrecognizedFunctions = false;
 
+    @Option(name = "--allow-duplicate-declarations", usage =
+        "Allow duplicate declarations.")
+    private boolean allowDuplicateDeclarations = false;
+
     @Option(name = "--allowed-non-standard-function", usage =
         "Specify a non-standard function to whitelist, like alpha()")
     private List<String> allowedNonStandardFunctions = Lists.newArrayList();
@@ -223,6 +227,7 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
       builder.setTrueConditionNames(trueConditions);
       builder.setAllowDefPropagation(allowDefPropagation);
       builder.setAllowUnrecognizedFunctions(allowUnrecognizedFunctions);
+      builder.setAllowDuplicateDeclarations(allowDuplicateDeclarations);
       builder.setAllowedNonStandardFunctions(allowedNonStandardFunctions);
       builder.setAllowedUnrecognizedProperties(allowedUnrecognizedProperties);
       builder.setAllowUnrecognizedProperties(allowUnrecognizedProperties);

--- a/src/com/google/common/css/compiler/passes/PassRunner.java
+++ b/src/com/google/common/css/compiler/passes/PassRunner.java
@@ -143,7 +143,7 @@ public class PassRunner {
           cssTree.getMutatingVisitController()).runPass();
     }
     // Report errors for duplicate declarations
-    if (job.allowDuplicateDeclarations) { 
+    if (!job.allowDuplicateDeclarations) {
       new DisallowDuplicateDeclarations(
           cssTree.getVisitController(), errorManager).runPass();
     }

--- a/src/com/google/common/css/compiler/passes/PassRunner.java
+++ b/src/com/google/common/css/compiler/passes/PassRunner.java
@@ -142,10 +142,12 @@ public class PassRunner {
       new AbbreviatePositionalValues(
           cssTree.getMutatingVisitController()).runPass();
     }
-    if (job.eliminateDeadStyles) {
-      // Report errors for duplicate declarations
+    // Report errors for duplicate declarations
+    if (job.allowDuplicateDeclarations) { 
       new DisallowDuplicateDeclarations(
           cssTree.getVisitController(), errorManager).runPass();
+    }
+    if (job.eliminateDeadStyles) {
       // Split rules by selector and declaration.
       new SplitRulesetNodes(cssTree.getMutatingVisitController()).runPass();
       // Dead code elimination.


### PR DESCRIPTION
Adds support for flag `--allow-duplicate-declarations`.

Please note was originally implmented by @amralassal here https://github.com/google/closure-stylesheets/pull/75 however I needed this feature ASAP so implemented myself.