### PR TITLE
Support --allow-duplicate-declarations

### DIFF
--- a/src/com/google/common/css/JobDescription.java
+++ b/src/com/google/common/css/JobDescription.java
@@ -47,6 +47,7 @@ public class JobDescription {
   public final boolean simplifyCss;
   public final boolean eliminateDeadStyles;
   public final boolean allowDefPropagation;
+  public final boolean allowDuplicateDeclarations;
   public final boolean allowUnrecognizedFunctions;
   public final Set<String> allowedNonStandardFunctions;
   public final boolean allowUnrecognizedProperties;
@@ -124,6 +125,7 @@ public class JobDescription {
       boolean useInternalBidiFlipper, boolean swapLtrRtlInUrl,
       boolean swapLeftRightInUrl, boolean simplifyCss,
       boolean eliminateDeadStyles, boolean allowDefPropagation,
+      boolean allowDuplicateDeclarations,
       boolean allowUnrecognizedFunctions,
       Set<String> allowedNonStandardFunctions,
       boolean allowUnrecognizedProperties,
@@ -162,6 +164,7 @@ public class JobDescription {
     this.simplifyCss = simplifyCss;
     this.eliminateDeadStyles = eliminateDeadStyles;
     this.allowDefPropagation = allowDefPropagation;
+    this.allowDuplicateDeclarations = allowDuplicateDeclarations;
     this.allowUnrecognizedFunctions = allowUnrecognizedFunctions;
     this.allowedNonStandardFunctions = ImmutableSet.copyOf(
         allowedNonStandardFunctions);

--- a/src/com/google/common/css/JobDescriptionBuilder.java
+++ b/src/com/google/common/css/JobDescriptionBuilder.java
@@ -51,6 +51,7 @@ public class JobDescriptionBuilder {
   boolean simplifyCss;
   boolean eliminateDeadStyles;
   boolean allowDefPropagation;
+  boolean allowDuplicateDeclarations;
   boolean allowUnrecognizedFunctions;
   Set<String> allowedNonStandardFunctions;
   boolean allowUnrecognizedProperties;
@@ -88,6 +89,7 @@ public class JobDescriptionBuilder {
     this.simplifyCss = false;
     this.eliminateDeadStyles = false;
     this.allowDefPropagation = false;
+    this.allowDuplicateDeclarations = false;
     this.allowUnrecognizedFunctions = false;
     this.allowedNonStandardFunctions = Sets.newHashSet();
     this.allowUnrecognizedProperties = false;
@@ -411,6 +413,16 @@ public class JobDescriptionBuilder {
     return setAllowDefPropagation(true);
   }
 
+  public JobDescriptionBuilder setAllowDuplicateDeclarations(boolean allow) {
+    checkJobIsNotAlreadyCreated();
+    this.allowDuplicateDeclarations = allow;
+    return this;
+  }
+
+  public JobDescriptionBuilder allowDuplicateDeclarations() {
+    return setAllowDuplicateDeclarations(true);
+  }
+
   public JobDescriptionBuilder setAllowUndefinedConstants(boolean allow) {
     checkJobIsNotAlreadyCreated();
     this.allowUndefinedConstants = allow;
@@ -464,7 +476,7 @@ public class JobDescriptionBuilder {
         copyrightNotice, outputFormat, inputOrientation, outputOrientation,
         optimize, trueConditionNames, useInternalBidiFlipper, swapLtrRtlInUrl,
         swapLeftRightInUrl, simplifyCss, eliminateDeadStyles,
-        allowDefPropagation, allowUnrecognizedFunctions, allowedNonStandardFunctions,
+        allowDefPropagation, allowDuplicateDeclarations, allowUnrecognizedFunctions, allowedNonStandardFunctions,
         allowUnrecognizedProperties, allowedUnrecognizedProperties, allowUndefinedConstants,
         allowMozDocument, vendor,
         allowKeyframes, allowWebkitKeyframes, processDependencies,

--- a/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
@@ -149,6 +149,10 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
         + " from one file to propagate to other files.")
     private boolean allowDefPropagation = true;
 
+    @Option(name = "--allow-duplicate-declarations", usage = "Allow duplicate"
+      + " declarations without needing @alternate")
+    private boolean allowDuplicateDeclarations = false;
+
     @Option(name = "--allow-unrecognized-functions", usage =
         "Allow unrecognized functions.")
     private boolean allowUnrecognizedFunctions = false;
@@ -222,6 +226,7 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
       builder.setCopyrightNotice(copyrightNotice);
       builder.setTrueConditionNames(trueConditions);
       builder.setAllowDefPropagation(allowDefPropagation);
+      builder.setAllowDuplicateDeclarations(allowDuplicateDeclarations);
       builder.setAllowUnrecognizedFunctions(allowUnrecognizedFunctions);
       builder.setAllowedNonStandardFunctions(allowedNonStandardFunctions);
       builder.setAllowedUnrecognizedProperties(allowedUnrecognizedProperties);

--- a/src/com/google/common/css/compiler/passes/PassRunner.java
+++ b/src/com/google/common/css/compiler/passes/PassRunner.java
@@ -144,9 +144,11 @@ public class PassRunner {
           cssTree.getMutatingVisitController()).runPass();
     }
     if (job.eliminateDeadStyles) {
-      // Report errors for duplicate declarations
-      new DisallowDuplicateDeclarations(
-          cssTree.getVisitController(), errorManager).runPass();
+      if (!job.allowDuplicateDeclarations) {
+        // Report errors for duplicate declarations
+        new DisallowDuplicateDeclarations(
+                cssTree.getVisitController(), errorManager).runPass();
+      }
       // Split rules by selector and declaration.
       new SplitRulesetNodes(cssTree.getMutatingVisitController()).runPass();
       // Dead code elimination.

--- a/tests/com/google/common/css/compiler/commandline/ClosureCommandLineCompilerTest.java
+++ b/tests/com/google/common/css/compiler/commandline/ClosureCommandLineCompilerTest.java
@@ -68,6 +68,13 @@ public class ClosureCommandLineCompilerTest extends TestCase {
     assertTrue(jobDescription.allowDefPropagation);
   }
 
+  public void testAllowDuplicateDeclarationsDefaultsToFalse() throws Exception {
+    ClosureCommandLineCompiler.Flags flags =
+            ClosureCommandLineCompiler.parseArgs(new String[] {"/dev/null"}, EXIT_CODE_HANDLER);
+    JobDescription jobDescription = flags.createJobDescription();
+    assertFalse(jobDescription.allowDuplicateDeclarations);
+  }
+
 
   public void testEmptyImportBlocks() throws Exception {
     // See b/29995881


### PR DESCRIPTION
When using CSS transform tools such as autoprefixer, the generated code
can include duplicate declarations but not include the alternate
annotation. This allows developers to opt out of the check during the
dead code elimination pass.