### PR TITLE
Improve SourceCodeLocation accuracy.

### DIFF
--- a/src/com/google/common/css/compiler/ast/CssDeclarationNode.java
+++ b/src/com/google/common/css/compiler/ast/CssDeclarationNode.java
@@ -18,6 +18,7 @@ package com.google.common.css.compiler.ast;
 
 import com.google.common.base.Preconditions;
 
+import com.google.common.css.SourceCodeLocation;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -39,63 +40,55 @@ public class CssDeclarationNode extends CssNode {
    */
   private boolean hasStarHack;
 
-  /**
-   * Constructor of a node representing a CSS declaration.
-   *
-   * @param propertyName
-   */
+  /** Constructor of a node representing a CSS declaration. */
   public CssDeclarationNode(CssPropertyNode propertyName) {
-    this(propertyName, new CssPropertyValueNode());
+    this(propertyName, new CssPropertyValueNode(), null /* sourceCodeLocation */);
   }
 
-  /**
-   * Constructor of a node representing a CSS declaration.
-   *
-   * @param propertyName
-   * @param comments
-   */
-  public CssDeclarationNode(CssPropertyNode propertyName,
-                            List<CssCommentNode> comments) {
-    this(propertyName, new CssPropertyValueNode(), comments);
+  /** Constructor of a node representing a CSS declaration. */
+  public CssDeclarationNode(
+      CssPropertyNode propertyName, @Nullable SourceCodeLocation sourceCodeLocation) {
+    this(propertyName, new CssPropertyValueNode(), sourceCodeLocation);
   }
 
-  /**
-   * Constructor of a node representing a CSS declaration.
-   *
-   * @param propertyName
-   * @param propertyValue
-   */
-  public CssDeclarationNode(CssPropertyNode propertyName,
-                            CssPropertyValueNode propertyValue) {
-    this(propertyName, propertyValue, null);
+  /** Constructor of a node representing a CSS declaration. */
+  public CssDeclarationNode(CssPropertyNode propertyName, List<CssCommentNode> comments) {
+    this(propertyName, comments, null /* sourceCodeLocation */);
   }
 
-  /**
-   * Constructor of a node representing a CSS declaration.
-   *
-   * @param propertyName
-   * @param propertyValue
-   * @param comments
-   */
-  public CssDeclarationNode(CssPropertyNode propertyName,
-                            CssPropertyValueNode propertyValue,
-                            @Nullable List<CssCommentNode> comments) {
-    this(propertyName, propertyValue, comments, false);
+  /** Constructor of a node representing a CSS declaration. */
+  public CssDeclarationNode(
+      CssPropertyNode propertyName,
+      List<CssCommentNode> comments,
+      @Nullable SourceCodeLocation sourceCodeLocation) {
+    this(propertyName, new CssPropertyValueNode(), comments, sourceCodeLocation);
   }
 
-  /**
-   * Constructor of a node representing a CSS declaration.
-   *
-   * @param propertyName
-   * @param propertyValue
-   * @param comments
-   * @param hasStarHack
-   */
-  public CssDeclarationNode(CssPropertyNode propertyName,
-                            CssPropertyValueNode propertyValue,
-                            @Nullable List<CssCommentNode> comments,
-                            boolean hasStarHack) {
-    super(null, comments, null);
+  /** Constructor of a node representing a CSS declaration. */
+  public CssDeclarationNode(
+      CssPropertyNode propertyName,
+      CssPropertyValueNode propertyValue,
+      @Nullable SourceCodeLocation sourceCodeLocation) {
+    this(propertyName, propertyValue, null, sourceCodeLocation);
+  }
+
+  /** Constructor of a node representing a CSS declaration. */
+  public CssDeclarationNode(
+      CssPropertyNode propertyName,
+      CssPropertyValueNode propertyValue,
+      @Nullable List<CssCommentNode> comments,
+      @Nullable SourceCodeLocation sourceCodeLocation) {
+    this(propertyName, propertyValue, comments, sourceCodeLocation, false);
+  }
+
+  /** Constructor of a node representing a CSS declaration. */
+  public CssDeclarationNode(
+      CssPropertyNode propertyName,
+      CssPropertyValueNode propertyValue,
+      @Nullable List<CssCommentNode> comments,
+      @Nullable SourceCodeLocation sourceCodeLocation,
+      boolean hasStarHack) {
+    super(null, comments, sourceCodeLocation);
     this.propertyName = propertyName;
     this.propertyValue = propertyValue;
     becomeParentForNode(this.propertyName);
@@ -103,17 +96,19 @@ public class CssDeclarationNode extends CssNode {
     this.setStarHack(hasStarHack);
   }
 
-  /**
-   * Copy constructor.
-   *
-   * @param node
-   */
+  /** Copy constructor. */
   public CssDeclarationNode(CssDeclarationNode node) {
     this(
         node.getPropertyName().deepCopy(),
         node.getPropertyValue().deepCopy(),
         node.getComments(),
+        node.getSourceCodeLocation(),
         node.hasStarHack());
+  }
+
+  public CssDeclarationNode(CssPropertyNode propertyNode,
+      CssPropertyValueNode cssPropertyValueNode) {
+    this(propertyNode, cssPropertyValueNode, null /* sourceCodeLocation */);
   }
 
   @Override

--- a/src/com/google/common/css/compiler/ast/CssNodesListNode.java
+++ b/src/com/google/common/css/compiler/ast/CssNodesListNode.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+import com.google.common.css.SourceCodeLocation;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -188,5 +189,14 @@ public abstract class CssNodesListNode<T extends CssNode> extends CssNode {
     }
 
     return output.toString();
+  }
+
+  @Override
+  public SourceCodeLocation getSourceCodeLocation() {
+    SourceCodeLocation location = super.getSourceCodeLocation();
+    if (location == null) {
+      location = SourceCodeLocation.merge(children);
+    }
+    return location;
   }
 }

--- a/src/com/google/common/css/compiler/ast/GssParserCC.jj
+++ b/src/com/google/common/css/compiler/ast/GssParserCC.jj
@@ -133,7 +133,7 @@ public class GssParserCC {
     int charIndex1 = charStream.convertToCharacterIndex(lineNumber1,
         indexInLine1);
     int lineNumber2 = t.endLine;
-    int indexInLine2 = t.endColumn;
+    int indexInLine2 = t.endColumn + 1; // Need to advance 1 to be beyond the end of the token.
     int charIndex2 = charStream.convertToCharacterIndex(lineNumber2,
         indexInLine2);
     return new SourceCodeLocation(sourceCode, charIndex1, lineNumber1,
@@ -423,10 +423,11 @@ public class GssParserCC {
 
     public CssDeclarationNode buildDeclarationNode(CssPropertyNode property,
         CssPropertyValueNode value, List<Token> tokens) {
-      CssDeclarationNode node = new CssDeclarationNode(property, value);
-      node.setSourceCodeLocation(
-        mergeLocations(
-          property.getSourceCodeLocation(), value.getSourceCodeLocation()));
+      CssDeclarationNode node =
+          new CssDeclarationNode(
+              property,
+              value,
+              mergeLocations(property.getSourceCodeLocation(), value.getSourceCodeLocation()));
       attachComments(tokens, node);
       return node;
     }
@@ -797,7 +798,7 @@ CssRulesetNode ruleSet() :
     t = <RIGHTBRACE> { tokens.add(t); }
     {
       CssRulesetNode ruleSet = nodeBuilder.buildRulesetNode(declarations,
-          selectors, this.getLocation(), tokens);
+          selectors, mergeLocations(selectors.getSourceCodeLocation(), getLocation()), tokens);
       return ruleSet;
     }
   } catch (ParseException e) {

--- a/src/com/google/common/css/compiler/passes/AutoExpandBrowserPrefix.java
+++ b/src/com/google/common/css/compiler/passes/AutoExpandBrowserPrefix.java
@@ -112,8 +112,10 @@ public final class AutoExpandBrowserPrefix extends DefaultTreeVisitor
           for (CssPropertyValueNode ruleValueNode : rule.getValueOnlyExpansionNodes()) {
             // For valueOnlyExpansionNodes the property name comes from the declaration.
             CssDeclarationNode expansionNode =
-                new CssDeclarationNode(declaration.getPropertyName(), ruleValueNode.deepCopy());
-            expansionNode.setSourceCodeLocation(declaration.getSourceCodeLocation());
+                new CssDeclarationNode(
+                    declaration.getPropertyName(),
+                    ruleValueNode.deepCopy(),
+                    declaration.getSourceCodeLocation());
             expansionNode.appendComment(new CssCommentNode("/* @alternate */", null));
             expansionNodes.add(expansionNode);
           }
@@ -207,8 +209,8 @@ public final class AutoExpandBrowserPrefix extends DefaultTreeVisitor
       // For valueOnlyExpansionNodes the property name comes from the declaration.
       CssPropertyValueNode expansionValues = new CssPropertyValueNode(expansionNodeValues);
       CssDeclarationNode expansionNode =
-          new CssDeclarationNode(declaration.getPropertyName(), expansionValues);
-      expansionNode.setSourceCodeLocation(declaration.getSourceCodeLocation());
+          new CssDeclarationNode(
+              declaration.getPropertyName(), expansionValues, declaration.getSourceCodeLocation());
       expansionNode.appendComment(new CssCommentNode("/* @alternate */", null));
       expansionNodes.add(expansionNode);
     }

--- a/src/com/google/common/css/compiler/passes/FixupFontDeclarations.java
+++ b/src/com/google/common/css/compiler/passes/FixupFontDeclarations.java
@@ -527,7 +527,7 @@ public class FixupFontDeclarations extends DefaultTreeVisitor
         ? ImmutableList.<CssValueNode>of()
         : ImmutableList.<CssValueNode>of(reparseFamilies(
             families,
-            getSourceCodeLocation(Iterables.get(families, 0))));
+            SourceCodeLocation.merge(families)));
     ImmutableList.Builder<CssValueNode> resultNodes = ImmutableList.builder();
     resultNodes.addAll(Iterables.concat(preFamily, tail));
     if (priority != null) {
@@ -611,6 +611,8 @@ public class FixupFontDeclarations extends DefaultTreeVisitor
         alternatives.add(stump);
       }
       stump.setValue(stump.getValue() + item.getValue());
+      stump.setSourceCodeLocation(
+          SourceCodeLocation.merge(stump.getSourceCodeLocation(), item.getSourceCodeLocation()));
       for (CssCommentNode c : item.getComments()) {
         stump.appendComment(c);
       }

--- a/tests/com/google/common/css/compiler/ast/SourceCodeLocationTest.java
+++ b/tests/com/google/common/css/compiler/ast/SourceCodeLocationTest.java
@@ -1,0 +1,211 @@
+package com.google.common.css.compiler.ast;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.css.compiler.ast.testing.SourceCodeLocationSubject.assertThat;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Iterables;
+import com.google.common.css.SourceCodeLocation;
+import com.google.common.css.compiler.ast.testing.TestParser;
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests that {@link com.google.common.css.SourceCodeLocation}s are created properly. */
+@RunWith(JUnit4.class)
+public class SourceCodeLocationTest {
+
+  private TestParser testParser = new TestParser();
+
+  @Test
+  @Ignore // The parser does not handle @charset.
+  public void testCharset() throws Exception {
+    CssTree tree = parse("@charset 'UTF-8';");
+    CssAtRuleNode charsetRule = tree.getRoot().getCharsetRule();
+    SourceCodeLocation location = charsetRule.getSourceCodeLocation();
+
+    assertThat(location.getBeginLineNumber()).isEqualTo(1);
+    assertThat(location.getBeginIndexInLine()).isEqualTo(1);
+  }
+
+  @Test
+  @Ignore // The parser does not handle @import.
+  public void testImport() throws Exception {
+    CssTree tree = parse("@import ull('funky.css');");
+    CssImportBlockNode importRules = tree.getRoot().getImportRules();
+    CssImportRuleNode importRule = getOnlyElement(importRules.getChildren());
+    SourceCodeLocation location = importRule.getSourceCodeLocation();
+
+    assertThat(location.getBeginLineNumber()).isEqualTo(1);
+    assertThat(location.getBeginIndexInLine()).isEqualTo(1);
+  }
+
+  @Test
+  public void testSimpleRule() throws Exception {
+    CssTree tree = parse(".foo {}");
+    List<CssNode> rules = tree.getRoot().getBody().getChildren();
+    CssRulesetNode rule = (CssRulesetNode) getOnlyElement(rules);
+    assertThat(rule.getSourceCodeLocation()).hasSpan(1, 1, 1, 8);
+    assertThat(rule.getSourceCodeLocation()).matches(".foo {}");
+
+    CssSelectorListNode selectors = rule.getSelectors();
+    assertThat(selectors.getSourceCodeLocation()).hasSpan(1, 1, 1, 5);
+    assertThat(selectors.getSourceCodeLocation()).matches(".foo");
+
+    CssSelectorNode selector = getOnlyElement(selectors.getChildren());
+    assertThat(selector.getSourceCodeLocation()).hasSpan(1, 1, 1, 5);
+    assertThat(selector.getSourceCodeLocation()).matches(".foo");
+
+    assertThat(selector.getCombinator()).isNull();
+
+    CssRefinerListNode refiners = selector.getRefiners();
+    assertThat(refiners.getSourceCodeLocation()).hasSpan(1, 2, 1, 5);
+    assertThat(refiners.getSourceCodeLocation()).matches("foo");
+
+    CssRefinerNode refiner = getOnlyElement(refiners.getChildren());
+    assertThat(refiner.getSourceCodeLocation()).hasSpan(1, 2, 1, 5);
+    assertThat(refiner.getSourceCodeLocation()).matches("foo");
+
+    CssDeclarationBlockNode declarations = rule.getDeclarations();
+    assertThat(declarations.getSourceCodeLocation())
+        .isUnknown(); // This is because the braces aren't part of the node.
+  }
+
+  @Test
+  public void testTwoSimpleRules() throws Exception {
+    CssTree tree = parse(".foo {}\n.bar {}");
+    List<CssNode> rules = tree.getRoot().getBody().getChildren();
+    CssRulesetNode rule = (CssRulesetNode) rules.get(0);
+    assertThat(rule.getSourceCodeLocation()).hasSpan(1, 1, 1, 8);
+    assertThat(rule.getSourceCodeLocation()).matches(".foo {}");
+
+    CssSelectorListNode selectors = rule.getSelectors();
+    assertThat(selectors.getSourceCodeLocation()).hasSpan(1, 1, 1, 5);
+    assertThat(selectors.getSourceCodeLocation()).matches(".foo");
+
+    rule = (CssRulesetNode) rules.get(1);
+    assertThat(rule.getSourceCodeLocation()).hasSpan(2, 1, 2, 8);
+    assertThat(rule.getSourceCodeLocation()).matches(".bar {}");
+
+    selectors = rule.getSelectors();
+    assertThat(selectors.getSourceCodeLocation()).hasSpan(2, 1, 2, 5);
+    assertThat(selectors.getSourceCodeLocation()).matches(".bar");
+  }
+
+  @Test
+  public void testRuleWithDeclaration() throws Exception {
+    CssTree tree = parse(".foo {\n  background-color: blue\n}");
+    List<CssNode> rules = tree.getRoot().getBody().getChildren();
+    CssRulesetNode rule = (CssRulesetNode) getOnlyElement(rules);
+    assertThat(rule.getSourceCodeLocation()).hasSpan(1, 1, 3, 2); // whole thing
+
+    CssSelectorListNode selectors = rule.getSelectors();
+    assertThat(selectors.getSourceCodeLocation()).hasSpan(1, 1, 1, 5);
+    assertThat(selectors.getSourceCodeLocation()).matches(".foo");
+
+    CssDeclarationBlockNode declarations = rule.getDeclarations();
+    assertThat(declarations.getSourceCodeLocation()).hasSpan(2, 3, 2, 25);
+    assertThat(declarations.getSourceCodeLocation()).matches("background-color: blue");
+
+    CssDeclarationNode declaration =
+        (CssDeclarationNode) Iterables.getOnlyElement(declarations.getChildren());
+    assertThat(declaration.getSourceCodeLocation()).hasSpan(2, 3, 2, 25);
+
+    CssPropertyNode propertyName = declaration.getPropertyName();
+    assertThat(propertyName.getSourceCodeLocation()).hasSpan(2, 3, 2, 19);
+    assertThat(propertyName.getSourceCodeLocation()).matches("background-color");
+
+    CssPropertyValueNode propertyValueNode = declaration.getPropertyValue();
+    assertThat(propertyValueNode.getSourceCodeLocation()).hasSpan(2, 21, 2, 25);
+    assertThat(propertyValueNode.getSourceCodeLocation()).matches("blue");
+  }
+
+  @Test
+  public void testRuleWithTwoDeclarations() throws Exception {
+    CssTree tree = parse(".foo {\n  background-color: blue;\n  text-color: red\n}");
+    List<CssNode> rules = tree.getRoot().getBody().getChildren();
+    CssRulesetNode rule = (CssRulesetNode) getOnlyElement(rules);
+    assertThat(rule.getSourceCodeLocation()).hasSpan(1, 1, 4, 2); // whole thing
+
+    CssSelectorListNode selectors = rule.getSelectors();
+    assertThat(selectors.getSourceCodeLocation()).hasSpan(1, 1, 1, 5);
+    assertThat(selectors.getSourceCodeLocation()).matches(".foo");
+
+    CssDeclarationBlockNode declarations = rule.getDeclarations();
+    assertThat(declarations.getSourceCodeLocation()).hasSpan(2, 3, 3, 18);
+    assertThat(declarations.getSourceCodeLocation())
+        .matches("background-color: blue;\n  text-color: red");
+
+    CssDeclarationNode declaration = (CssDeclarationNode) declarations.getChildren().get(0);
+    assertThat(declaration.getSourceCodeLocation()).hasSpan(2, 3, 2, 25);
+    assertThat(declaration.getSourceCodeLocation()).matches("background-color: blue");
+
+    CssPropertyNode propertyName = declaration.getPropertyName();
+    assertThat(propertyName.getSourceCodeLocation()).hasSpan(2, 3, 2, 19);
+    assertThat(propertyName.getSourceCodeLocation()).matches("background-color");
+
+    CssPropertyValueNode propertyValueNode = declaration.getPropertyValue();
+    assertThat(propertyValueNode.getSourceCodeLocation()).hasSpan(2, 21, 2, 25);
+    assertThat(propertyValueNode.getSourceCodeLocation()).matches("blue");
+
+    declaration = (CssDeclarationNode) declarations.getChildren().get(1);
+    assertThat(declaration.getSourceCodeLocation()).hasSpan(3, 3, 3, 18);
+    assertThat(declaration.getSourceCodeLocation()).matches("text-color: red");
+
+    propertyName = declaration.getPropertyName();
+    assertThat(propertyName.getSourceCodeLocation()).hasSpan(3, 3, 3, 13);
+    assertThat(propertyName.getSourceCodeLocation()).matches("text-color");
+
+    propertyValueNode = declaration.getPropertyValue();
+    assertThat(propertyValueNode.getSourceCodeLocation()).hasSpan(3, 15, 3, 18);
+    assertThat(propertyValueNode.getSourceCodeLocation()).matches("red");
+  }
+
+  @Test
+  public void testRuleWithFontDeclaration() throws Exception {
+    CssTree tree = parse(".foo {\n  font: 12pt Times New Roman, serif;\n}");
+    List<CssNode> rules = tree.getRoot().getBody().getChildren();
+    CssRulesetNode rule = (CssRulesetNode) getOnlyElement(rules);
+    CssDeclarationBlockNode declarations = rule.getDeclarations();
+    CssDeclarationNode declaration =
+        (CssDeclarationNode) Iterables.getOnlyElement(declarations.getChildren());
+    assertThat(declaration.getSourceCodeLocation()).hasSpan(2, 3, 2, 36);
+    assertThat(declaration.getSourceCodeLocation()).matches("font: 12pt Times New Roman, serif");
+
+    CssPropertyNode propertyName = declaration.getPropertyName();
+    assertThat(propertyName.getSourceCodeLocation()).hasSpan(2, 3, 2, 7);
+    assertThat(propertyName.getSourceCodeLocation()).matches("font");
+
+    CssPropertyValueNode propertyValueNode = declaration.getPropertyValue();
+    assertThat(propertyValueNode.getSourceCodeLocation()).hasSpan(2, 9, 2, 36);
+    assertThat(propertyValueNode.getSourceCodeLocation()).matches("12pt Times New Roman, serif");
+
+    List<CssValueNode> valueNodes = propertyValueNode.getChildren();
+    assertThat(valueNodes).hasSize(2);
+
+    CssNumericNode cssNumericNode = (CssNumericNode) valueNodes.get(0);
+    assertThat(cssNumericNode.getSourceCodeLocation()).hasSpan(2, 9, 2, 13);
+    assertThat(cssNumericNode.getSourceCodeLocation()).matches("12pt");
+
+    CssCompositeValueNode cssCompositeValueNode = (CssCompositeValueNode) valueNodes.get(1);
+    assertThat(cssCompositeValueNode.getSourceCodeLocation()).hasSpan(2, 14, 2, 36);
+    assertThat(cssCompositeValueNode.getSourceCodeLocation()).matches("Times New Roman, serif");
+
+    assertThat(cssCompositeValueNode.getValues()).hasSize(2);
+    assertThat(cssCompositeValueNode.getValues().get(0).getSourceCodeLocation())
+        .hasSpan(2, 14, 2, 29);
+    assertThat(cssCompositeValueNode.getValues().get(0).getSourceCodeLocation())
+        .matches("Times New Roman");
+    assertThat(cssCompositeValueNode.getValues().get(1).getSourceCodeLocation())
+        .hasSpan(2, 31, 2, 36);
+    assertThat(cssCompositeValueNode.getValues().get(1).getSourceCodeLocation()).matches("serif");
+  }
+
+  private CssTree parse(String cssText) throws GssParserException {
+    testParser.addSource("test.css", cssText);
+    return testParser.parse();
+  }
+
+}

--- a/tests/com/google/common/css/compiler/ast/testing/SourceCodeLocationSubject.java
+++ b/tests/com/google/common/css/compiler/ast/testing/SourceCodeLocationSubject.java
@@ -1,0 +1,67 @@
+package com.google.common.css.compiler.ast.testing;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+import com.google.common.css.SourceCodeLocation;
+import com.google.common.truth.FailureStrategy;
+import com.google.common.truth.Subject;
+import com.google.common.truth.SubjectFactory;
+import javax.annotation.CheckReturnValue;
+
+/**
+ * Truth subject for {@link SourceCodeLocation}.
+ */
+public class SourceCodeLocationSubject
+    extends Subject<SourceCodeLocationSubject, SourceCodeLocation> {
+
+  static SubjectFactory<SourceCodeLocationSubject, SourceCodeLocation> LOCATION =
+      new SubjectFactory<SourceCodeLocationSubject, SourceCodeLocation>() {
+        @Override
+        public SourceCodeLocationSubject getSubject(FailureStrategy fs, SourceCodeLocation that) {
+          return new SourceCodeLocationSubject(fs, that);
+        }
+      };
+
+  @CheckReturnValue
+  public static SourceCodeLocationSubject assertThat(SourceCodeLocation target) {
+    return assertAbout(LOCATION).that(target);
+  }
+
+  public SourceCodeLocationSubject(FailureStrategy failureStrategy, SourceCodeLocation subject) {
+    super(failureStrategy, subject);
+  }
+
+  public void hasSpan(int beginLine, int beginIndex, int endLine, int endIndex) {
+    check().that(getSubject()).isNotNull();
+    if (!(beginLine == getSubject().getBeginLineNumber()
+        && beginIndex == getSubject().getBeginIndexInLine()
+        && endLine == getSubject().getEndLineNumber()
+        && endIndex == getSubject().getEndIndexInLine())) {
+      failWithRawMessage(
+          "Location did not match <%s,%s -> %s,%s>, was <%s,%s -> %s,%s>",
+          String.valueOf(beginLine),
+          String.valueOf(beginIndex),
+          String.valueOf(endLine),
+          String.valueOf(endIndex),
+          String.valueOf(getSubject().getBeginLineNumber()),
+          String.valueOf(getSubject().getBeginIndexInLine()),
+          String.valueOf(getSubject().getEndLineNumber()),
+          String.valueOf(getSubject().getEndIndexInLine()));
+    }
+  }
+
+  public void matches(String text) {
+    check().that(getSubject()).isNotNull();
+    String source =
+        getSubject()
+            .getSourceCode()
+            .getFileContents()
+            .substring(
+                getSubject().getBeginCharacterIndex(), getSubject().getEndCharacterIndex());
+    check().that(source).isEqualTo(text);
+  }
+
+  public void isUnknown() {
+    check().that(getSubject().isUnknown()).named("isUnknown").isTrue();
+  }
+}

--- a/tests/com/google/common/css/compiler/ast/testing/TestParser.java
+++ b/tests/com/google/common/css/compiler/ast/testing/TestParser.java
@@ -1,0 +1,106 @@
+package com.google.common.css.compiler.ast.testing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.css.JobDescription.SourceMapDetailLevel;
+import com.google.common.css.SourceCode;
+import com.google.common.css.compiler.ast.CssTree;
+import com.google.common.css.compiler.ast.GssParser;
+import com.google.common.css.compiler.ast.GssParserException;
+import com.google.common.css.compiler.ast.testing.NewFunctionalTestBase.TestErrorManager;
+import com.google.common.css.compiler.passes.CompactPrinter;
+import com.google.common.css.compiler.passes.CreateStandardAtRuleNodes;
+import com.google.common.css.compiler.passes.DefaultGssSourceMapGenerator;
+import com.google.common.css.compiler.passes.FixupFontDeclarations;
+import com.google.common.css.compiler.passes.FixupFontDeclarations.InputMode;
+import com.google.common.css.compiler.passes.GssSourceMapGenerator;
+import com.google.common.io.Files;
+import com.google.debugging.sourcemap.SourceMapConsumerFactory;
+import com.google.debugging.sourcemap.SourceMapParseException;
+import com.google.debugging.sourcemap.SourceMapping;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Simple framework for creating a parser for testing. */
+public class TestParser {
+
+  private CssTree tree;
+  private List<SourceCode> sources = new ArrayList<>();
+  private TestErrorManager errorManager = new TestErrorManager(new String[0]);
+  private GssSourceMapGenerator generator =
+      new DefaultGssSourceMapGenerator(SourceMapDetailLevel.ALL);
+  private String output = null;
+  private SourceMapping sourceMap = null;
+  private String sourceMapString = null;
+
+  public void addSource(String filename, String code) {
+    sources.add(new SourceCode(filename, code));
+  }
+
+  /**
+   * Parses GSS style sheets and returns one tree containing everything.
+   *
+   * @return the CSS tree created by the parser
+   */
+  public CssTree parse() throws GssParserException {
+    tree = new GssParser(sources).parse();
+    runPasses(tree);
+    return tree;
+  }
+
+  protected void runPasses(CssTree tree) {
+    new CreateStandardAtRuleNodes(tree.getMutatingVisitController(), errorManager).runPass();
+    new FixupFontDeclarations(InputMode.CSS, errorManager, tree).runPass();
+  }
+
+  public String getOutput() {
+    if (output == null) {
+      CompactPrinter compactPrinter = new CompactPrinter(tree, generator);
+      compactPrinter.runPass();
+      output = compactPrinter.getCompactPrintedString();
+    }
+    return output;
+  }
+
+  public SourceMapping getSourceMap() throws IOException, SourceMapParseException {
+    if (sourceMap == null) {
+      sourceMap = SourceMapConsumerFactory.parse(getSourceMapString());
+    }
+    return sourceMap;
+  }
+
+  private String getSourceMapString() throws IOException {
+    if (sourceMapString == null) {
+      StringBuffer sourceMapBuffer = new StringBuffer();
+      generator.appendOutputTo(sourceMapBuffer, "test");
+      sourceMapString = sourceMapBuffer.toString();
+    }
+    return sourceMapString;
+  }
+
+  public void showSourceMap() throws IOException, InterruptedException {
+    File tmpDir = Files.createTempDir();
+    File sourcemapFile = new File(tmpDir, "sourcemap");
+    File compiledFile = new File(tmpDir, "compiled.css");
+
+    Files.write(getSourceMapString(), sourcemapFile, StandardCharsets.UTF_8);
+    Files.write(getOutput(), compiledFile, StandardCharsets.UTF_8);
+    for (SourceCode source : sources) {
+      Files.write(
+          source.getFileContents(), new File(tmpDir, source.getFileName()), StandardCharsets.UTF_8);
+    }
+    Process process =
+        new ProcessBuilder()
+            .directory(tmpDir)
+            .command(
+                "/usr/local/bin/source-map-visualize",
+                "compiled.css",
+                "sourcemap")
+            .start();
+    process.waitFor();
+    assertThat(process.exitValue()).named("visualization exit code").isEqualTo(0);
+  }
+}


### PR DESCRIPTION
CssDeclarationNode did not have the SourceCodeLocation as a constructor
parameter, nor did it preserve it on a deep copy.

CssNodesListNode now tries to build its locations from its constituent nodes
unless a SourceCodeLocation is set explicitly.

Several bugs in the actual parser are also fixed as are numerous problems in
FixupFontDeclarations.

There are new tests and a SourceCodeLocationSubject for Truth which should
make new tests easier to write.