### PR TITLE
Add --source_map_include_content option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.7</java.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>20.0</guava.version>
   </properties>
 
   <build>
@@ -186,7 +186,7 @@
     <dependency>  <!-- For com.google.debugging.sourcemap -->
       <groupId>com.google.javascript</groupId>
       <artifactId>closure-compiler-unshaded</artifactId>
-      <version>v20160713</version>
+      <version>v20170218</version>
     </dependency>
 
     <dependency>

--- a/src/com/google/common/css/JobDescription.java
+++ b/src/com/google/common/css/JobDescription.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
 /**
  * Provides inputs and options to Closure Stylesheets.
  * To construct an instance, use a {@link JobDescriptionBuilder}.
@@ -69,6 +68,7 @@ public class JobDescription {
   public final Map<String, Integer> compileConstants;
   public final boolean createSourceMap;
   public final SourceMapDetailLevel sourceMapLevel;
+  public final boolean sourceMapIncludeContent;
   public final boolean preserveImportantComments;
 
   static final String CONDITION_FOR_LTR = "GSS_LTR";
@@ -142,6 +142,7 @@ public class JobDescription {
       boolean suppressDependencyCheck, Map<String, Integer> compileConstants,
       boolean createSourceMap,
       SourceMapDetailLevel sourceMapLevel,
+      boolean sourceMapIncludeContent,
       boolean preserveImportantComments) {
     this.allowUndefinedConstants = allowUndefinedConstants;
     Preconditions.checkArgument(!inputs.contains(null));
@@ -190,6 +191,7 @@ public class JobDescription {
     this.compileConstants = ImmutableMap.copyOf(compileConstants);
     this.createSourceMap = createSourceMap;
     this.sourceMapLevel = sourceMapLevel;
+    this.sourceMapIncludeContent = sourceMapIncludeContent;
     this.preserveImportantComments = preserveImportantComments;
   }
 

--- a/src/com/google/common/css/JobDescriptionBuilder.java
+++ b/src/com/google/common/css/JobDescriptionBuilder.java
@@ -75,6 +75,7 @@ public class JobDescriptionBuilder {
   JobDescription job = null;
   boolean createSourceMap;
   SourceMapDetailLevel sourceMapLevel;
+  boolean sourceMapIncludeContent;
 
   public JobDescriptionBuilder() {
     this.inputs = Lists.newArrayList();
@@ -111,6 +112,7 @@ public class JobDescriptionBuilder {
     this.compileConstants = new HashMap<>();
     this.createSourceMap = false;
     this.sourceMapLevel = SourceMapDetailLevel.DEFAULT;
+    this.sourceMapIncludeContent = false;
     this.preserveImportantComments = false;
   }
 
@@ -151,6 +153,7 @@ public class JobDescriptionBuilder {
     setCompileConstants(jobToCopy.compileConstants);
     this.createSourceMap = jobToCopy.createSourceMap;
     this.sourceMapLevel = jobToCopy.sourceMapLevel;
+    this.sourceMapIncludeContent = jobToCopy.sourceMapIncludeContent;
     this.preserveImportantComments = jobToCopy.preserveImportantComments;
     return this;
   }
@@ -495,7 +498,8 @@ public class JobDescriptionBuilder {
         gssFunctionMapProvider, cssSubstitutionMapProvider,
         outputRenamingMapFormat, inputRenamingMap, preserveComments,
         suppressDependencyCheck, compileConstants,
-        createSourceMap, sourceMapLevel, preserveImportantComments);
+        createSourceMap, sourceMapLevel, sourceMapIncludeContent,
+        preserveImportantComments);
     return job;
   }
 
@@ -509,4 +513,8 @@ public class JobDescriptionBuilder {
     return this;
   }
 
+  public JobDescriptionBuilder setSourceMapIncludeContent(boolean sourceMapIncludeContent) {
+    this.sourceMapIncludeContent = sourceMapIncludeContent;
+    return this;
+  }
 }

--- a/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/ClosureCommandLineCompiler.java
@@ -145,6 +145,11 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
         + "mappings, and ALL, which outputs mappings for all elements.")
     private SourceMapDetailLevel sourceMapLevel = SourceMapDetailLevel.DEFAULT;
 
+    @Option(name = "--source_map_include_content", usage = "Includes sources "
+        + "content into source map. Greatly increases the size of source maps "
+        + "but offers greater portability (default: false)")
+    private boolean sourceMapIncludeContent = false;
+
     @Option(name = "--copyright-notice",
         usage = "Copyright notice to prepend to the output")
     private String copyrightNotice = null;
@@ -259,6 +264,7 @@ public class ClosureCommandLineCompiler extends DefaultCommandLineCompiler {
           getGssFunctionMapProviderForName(gssFunctionMapProviderClassName);
       builder.setGssFunctionMapProvider(gssFunctionMapProvider);
       builder.setSourceMapLevel(sourceMapLevel);
+      builder.setSourceMapIncludeContent(sourceMapIncludeContent);
       builder.setCreateSourceMap(!Strings.isNullOrEmpty(sourceMapFile));
 
       if (inputRenamingMapFileName != null) {

--- a/src/com/google/common/css/compiler/commandline/DefaultCommandLineCompiler.java
+++ b/src/com/google/common/css/compiler/commandline/DefaultCommandLineCompiler.java
@@ -81,7 +81,7 @@ public class DefaultCommandLineCompiler extends AbstractCommandLineCompiler<JobD
     if (!job.createSourceMap) {
       return new NullGssSourceMapGenerator();
     }
-    return new DefaultGssSourceMapGenerator(job.sourceMapLevel);
+    return new DefaultGssSourceMapGenerator(job.sourceMapLevel, job.sourceMapIncludeContent);
   }
 
   /**

--- a/tests/com/google/common/css/compiler/ast/testing/TestParser.java
+++ b/tests/com/google/common/css/compiler/ast/testing/TestParser.java
@@ -47,7 +47,7 @@ public class TestParser {
   private List<SourceCode> sources = new ArrayList<>();
   private TestErrorManager errorManager = new TestErrorManager(new String[0]);
   private GssSourceMapGenerator generator =
-      new DefaultGssSourceMapGenerator(SourceMapDetailLevel.ALL);
+      new DefaultGssSourceMapGenerator(SourceMapDetailLevel.ALL, true);
   private String output = null;
   private SourceMapping sourceMap = null;
   private String sourceMapString = null;


### PR DESCRIPTION
Closure-stylesheets lacks some source map options that exists in a latest closure-compiler. 
For example: --source_map_include_content, --source_map_input, --source_map_location_mapping

I implements source_map_include_content option for now. I wish to be implemented other options.