### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <version>3.0</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -169,12 +170,6 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.7</version>
-    </dependency>
-
-    <dependency>
-      <groupId>javacc</groupId>
-      <artifactId>javacc</artifactId>
-      <version>4.1</version>
     </dependency>
 
     <dependency>
@@ -200,6 +195,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The current pom.xml has unnecessary dependencies that use for test only.
I remove them.

- removes dependency for javacc.
- marks a test scope to easymock and mockito-core.