### PR TITLE
Added user-select support.

### DIFF
--- a/src/com/google/common/css/compiler/ast/Property.java
+++ b/src/com/google/common/css/compiler/ast/Property.java
@@ -564,6 +564,7 @@ public final class Property {
         builder("transition"),
         builder("unicode-bidi"),
         builder("unicode-range"),
+        builder("user-select"),
         builder("vector-effect").isSvgOnly(),
         builder("vertical-align"),
         builder("visibility"),


### PR DESCRIPTION
Added bare `user-select` support to closure-stylesheets.
Its absence was also described in issue #104 

Caniuse link : https://caniuse.com/#feat=user-select-none
MDN link : https://developer.mozilla.org/en-US/docs/Web/CSS/user-select

Vendor prefixed versions were already supported.